### PR TITLE
Include image URL in API response

### DIFF
--- a/app/views/games/_game.json.jbuilder
+++ b/app/views/games/_game.json.jbuilder
@@ -7,3 +7,4 @@ json.legacy_controls game.legacy_controls
 json.download_url    game.download_url
 json.last_modified   game.current_zip&.file_last_modified&.iso8601
 json.executable      game.current_zip&.executable
+json.image_url       game.images.first&.url

--- a/spec/controllers/api/v1/playlists_controller_spec.rb
+++ b/spec/controllers/api/v1/playlists_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V1::PlaylistsController, type: :controller do
 
   before :each do
     allow_any_instance_of(Game).to receive(:download_url).and_return("http://example.com/game.zip")
+    allow_any_instance_of(Image).to receive(:url).and_return("http://example.com/screenshot.png")
   end
 
   describe "GET index" do
@@ -29,7 +30,8 @@ RSpec.describe Api::V1::PlaylistsController, type: :controller do
                 "legacy_controls" => game.legacy_controls,
                 "download_url"    => game.download_url,
                 "last_modified"   => game.current_zip.file_last_modified.iso8601,
-                "executable"      => game.current_zip.executable
+                "executable"      => game.current_zip.executable,
+                "image_url"       => game.images.first.url
               }
             end
           }

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :game do
     title       { Faker::Lorem.words(3).join(" ") }
     description { Faker::Lorem.sentence(2) }
-    uuid        SecureRandom.uuid
+    uuid        { SecureRandom.uuid }
     min_players 1
     max_players 2
 
@@ -11,10 +11,15 @@ FactoryGirl.define do
       GameOwnership.create game: game, user: owner
 
       GameZip.create(game:     game,
-                     user:     FactoryGirl.create(:user),
+                     user:     owner,
                      file_key: [Faker::Lorem.word, ".zip"].join,
                      file_last_modified: Time.now,
                      executable: [Faker::Lorem.word, ".exe"].join)
+
+      Image.create(parent: game,
+                   user: owner,
+                   file_key: "screenshot.png",
+                   parent_uuid: game.uuid)
     end
   end
 end


### PR DESCRIPTION
A part of #42. Includes an `image_url` attr in the API response for the launcher to download.

Nothing here yet to manage which image gets returned (just picks the first one for now). 