### PR TITLE
Fix deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gem 'pg',    '~> 0.15'
 gem 'puma',  '~> 3.4.0'
 
 
-gem 'sass-rails', '~> 5.0'
-gem 'less-rails'
+gem 'sass-rails', '~> 5.0.6'
+gem 'less-rails', '~> 2.8.0'
 gem 'uglifier',   '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     jwt (1.5.6)
     less (2.6.0)
       commonjs (~> 0.2.7)
-    less-rails (2.7.1)
+    less-rails (2.8.0)
       actionpack (>= 4.0)
       less (~> 2.6.0)
       sprockets (> 2, < 4)
@@ -137,7 +137,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -180,7 +180,7 @@ GEM
     puma (3.4.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -241,8 +241,8 @@ GEM
       rails (>= 3.1)
       sass-rails (>= 3.1)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -267,7 +267,7 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
     twitter-bootstrap-rails (3.2.2)
@@ -303,7 +303,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-rails
-  less-rails
+  less-rails (~> 2.8.0)
   nested_form_fields!
   newrelic_rpm
   nokogiri (= 1.6.8)
@@ -319,7 +319,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails (~> 3.4.2)
   s3_direct_upload (~> 0.1.7)
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.0.6)
   sdoc (~> 0.4.0)
   simplecov
   spring

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,9 +14,9 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = true  
+  config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-  
-  config.include Devise::TestHelpers, :type => :controller
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
Closes #25, at least as much as it can be closed. `less-rails` still causes a couple warnings, but that's an open issue with them. Nothing to be done here.